### PR TITLE
Update graph.jsonld

### DIFF
--- a/graph.jsonld
+++ b/graph.jsonld
@@ -17,7 +17,7 @@
           "name": "Alex Corbi"
         },
         {
-          "id": "https://jonrichter.de",
+          "id": "https://almereyda.de",
           "name": "Jon Richter"
         }
       ],


### PR DESCRIPTION
HTTPS is currently only supported at another domain; same content.
